### PR TITLE
chore: add x-checker-data metadata for automated PRs

### DIFF
--- a/io.github.flattool.Warehouse.json
+++ b/io.github.flattool.Warehouse.json
@@ -37,7 +37,11 @@
 					"type": "git",
 					"tag": "2.2.0",
 					"commit": "4e45cb52caa7a32717b2037f4b0fb8a331c9e7c6",
-					"url": "https://github.com/flattool/warehouse.git"
+					"url": "https://github.com/flattool/warehouse.git",
+					"x-checker-data": {
+						"type": "git",
+						"tag-pattern": "^([\\d.]+)$"
+					}
 				}
 			]
 		}


### PR DESCRIPTION
This allows `flatpak-external-data-checker` to bump versions on the manifest automatically.

<https://docs.flathub.org/docs/for-app-authors/external-data-checker>

Example:
<img width="1592" height="716" alt="image" src="https://github.com/user-attachments/assets/ea8e9531-6347-4ac6-ae90-e6ed859d7ba3" />

